### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ daft.set_max_beds(2)
 listings = daft.search()
 properties = []
 print("Translating {} listing object into json, it will take a few minutes".format(str(len(listings))))
-print("Igonre the error message")
+print("Ignore the error message")
 for listing in listings:
     try:
         if listing.search_type != 'rental':
@@ -216,7 +216,7 @@ daft.set_max_beds(2)
 listings = daft.search()
 properties = []
 print("Translating {} listing object into json, it will take a few minutes".format(str(len(listings))))
-print("Igonre the error message")
+print("Ignore the error message")
 
 # time the translation
 start = time.time()

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ Save the map in a html file.
    listings = daft.search()
    properties = []
    print("Translating {} listing object into json, it will take a few minutes".format(str(len(listings))))
-   print("Igonre the error message")
+   print("Ignore the error message")
    for listing in listings:
       try:
          if listing.search_type != 'rental':


### PR DESCRIPTION
Just noticed this while I was snooping at the project (which looks class, nice job).

I'd recommend you delete either README.rst or README.md, as they're inevitably going to go out of sync (and they already do differ, it looks like).