### PR TITLE
Improving coverage

### DIFF
--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -80,6 +80,11 @@ class Daft:
             raise TypeError("Argument must be enums.PropertyType.")
         self._add_filter("propertyType", property_type.value)
 
+    def set_filter(self, misc_filter: MiscFilter):
+        if not isinstance(misc_filter, MiscFilter):
+            raise TypeError("Argument must be enums.MiscFilter.")
+        self._add_filter("facilities", misc_filter.value)
+
     def set_min_beds(self, min_beds: int):
         self._set_range_from("numBeds", str(min_beds))
 

--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -80,11 +80,6 @@ class Daft:
             raise TypeError("Argument must be enums.PropertyType.")
         self._add_filter("propertyType", property_type.value)
 
-    def set_filter(self, misc_filter: MiscFilter):
-        if not isinstance(misc_filter, MiscFilter):
-            raise TypeError("Argument must be enums.MiscFilter.")
-        self._add_filter("facilities", misc_filter.value)
-
     def set_min_beds(self, min_beds: int):
         self._set_range_from("numBeds", str(min_beds))
 

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -10,6 +10,7 @@ from daftlistings import (
     Listing,
     AddedSince,
     MiscFilter,
+    PropertyType,
 )
 
 

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -9,7 +9,6 @@ from daftlistings import (
     Ber,
     Listing,
     AddedSince,
-    MiscFilter,
     PropertyType,
 )
 
@@ -20,7 +19,6 @@ class DaftTest(unittest.TestCase):
         url = "https://search-gateway.dsch.ie/v1/listings"
         payload = {
             "section": "new-homes",
-            "filters": [{"name": "facilities", "values": ["auction"]}],
             "ranges": [
                 {"name": "salePrice", "from": "250000", "to": "300000"},
                 {"name": "numBeds", "from": "3", "to": "3"},
@@ -53,8 +51,6 @@ class DaftTest(unittest.TestCase):
         daft.set_max_floor_size(1000)
         daft.set_min_floor_size(1000)
         daft.set_added_since(AddedSince.DAYS_14)
-        daft.set_filter(MiscFilter.AUCTION)
-
         daft.search()
 
         mock_post.assert_called_with(url, headers=headers, json=payload)

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -1,7 +1,16 @@
 import json
 from unittest.mock import patch
 import unittest
-from daftlistings import Daft, Location, SearchType, SortType, Ber, Listing
+from daftlistings import (
+    Daft,
+    Location,
+    SearchType,
+    SortType,
+    Ber,
+    Listing,
+    AddedSince,
+    MiscFilter,
+)
 
 
 class DaftTest(unittest.TestCase):
@@ -10,11 +19,13 @@ class DaftTest(unittest.TestCase):
         url = "https://search-gateway.dsch.ie/v1/listings"
         payload = {
             "section": "new-homes",
+            "filters": [{"name": "facilities", "values": ["auction"]}],
             "ranges": [
                 {"name": "salePrice", "from": "250000", "to": "300000"},
                 {"name": "numBeds", "from": "3", "to": "3"},
                 {"name": "ber", "from": "0", "to": "0"},
                 {"name": "floorSize", "from": "1000", "to": "1000"},
+                {"name": "firstPublishDate", "from": "now-14d/d", "to": ""},
             ],
             "geoFilter": {"storedShapeIds": ["3"], "geoSearchType": "STORED_SHAPES"},
             "sort": "priceAsc",
@@ -30,6 +41,7 @@ class DaftTest(unittest.TestCase):
 
         daft.set_search_type(SearchType.NEW_HOMES)
         daft.set_location(Location.KILDARE)
+        daft.set_location("Kildare")
         daft.set_sort_type(SortType.PRICE_ASC)
         daft.set_max_price(300000)
         daft.set_min_price(250000)
@@ -39,6 +51,8 @@ class DaftTest(unittest.TestCase):
         daft.set_max_ber(Ber.A1)
         daft.set_max_floor_size(1000)
         daft.set_min_floor_size(1000)
+        daft.set_added_since(AddedSince.DAYS_14)
+        daft.set_filter(MiscFilter.AUCTION)
 
         daft.search()
 


### PR DESCRIPTION
@sdfordham, I added the set filter method which accepts the MiscFilter enum as argument. Could you please confirm if that's the correct usage? I noticed that the `add_filter` wasn't being called anywhere so added that and some test coverage.