### PR TITLE
Sublistings

### DIFF
--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -21,6 +21,7 @@ class Daft:
     _PAGE_0 = {"from": "0", "pagesize": str(_PAGE_SZ)}
 
     def __init__(self):
+        self._section = None
         self._filters = list()
         self._andFilters = list()
         self._ranges = list()

--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -3,6 +3,7 @@ import requests
 from typing import Union, Optional, List, Dict
 from math import ceil
 from difflib import SequenceMatcher
+from copy import deepcopy
 
 from .enums import *
 from .listing import Listing
@@ -232,5 +233,19 @@ class Daft:
                               headers=self._HEADER,
                               json=_payload)
             listings = listings + r.json()["listings"]
-        return [Listing(l) for l in listings]
+
+
+        expanded_listings = []
+        for l in listings:
+            if 'prs' in l['listing'].keys():
+                subUnit_keys = ['id', 'price', 'numBedrooms', 'numBathrooms', 'daftShortcode', 'seoFriendlyPath', 'category', 'media', 'ber']
+                num_subUnits = len(l['listing']['prs']['subUnits'])
+                for i in range(num_subUnits):   
+                    for key in subUnit_keys:     
+                        l['listing'][key] = l['listing']['prs']['subUnits'][i][key]
+                    expanded_listings.append(deepcopy(l))
+            else:
+                expanded_listings.append(l)
+
+        return [Listing(l) for l in expanded_listings]
 

--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -21,7 +21,6 @@ class Daft:
     _PAGE_0 = {"from": "0", "pagesize": str(_PAGE_SZ)}
 
     def __init__(self):
-        self._section = None
         self._filters = list()
         self._andFilters = list()
         self._ranges = list()
@@ -222,7 +221,6 @@ class Daft:
                           json=_payload)
         listings = r.json()["listings"]
         results_count = r.json()["paging"]["totalResults"]
-        print(f"Got {results_count} results.")
 
         total_pages = ceil(results_count / self._PAGE_SZ)
         limit = min(max_pages, total_pages) if max_pages else total_pages
@@ -234,11 +232,10 @@ class Daft:
                               json=_payload)
             listings = listings + r.json()["listings"]
 
-
         expanded_listings = []
+        subUnit_keys = ['id', 'price', 'numBedrooms', 'numBathrooms', 'daftShortcode', 'seoFriendlyPath', 'category', 'media', 'ber']
         for l in listings:
             if 'prs' in l['listing'].keys():
-                subUnit_keys = ['id', 'price', 'numBedrooms', 'numBathrooms', 'daftShortcode', 'seoFriendlyPath', 'category', 'media', 'ber']
                 num_subUnits = len(l['listing']['prs']['subUnits'])
                 for i in range(num_subUnits):   
                     for key in subUnit_keys:     
@@ -246,6 +243,9 @@ class Daft:
                     expanded_listings.append(deepcopy(l))
             else:
                 expanded_listings.append(l)
+
+        expanded_results_count = len(expanded_listings) 
+        print(f"Got {expanded_results_count} results.")
 
         return [Listing(l) for l in expanded_listings]
 

--- a/daftlistings/listing.py
+++ b/daftlistings/listing.py
@@ -59,13 +59,8 @@ class Listing:
             return price_num
 
     @property
-    def abbreviated_price(self):
-        return self._result["abbreviatedPrice"]
-
-    @property
     def bathrooms(self):
-        if "numBathrooms" in self._result:
-            return self._result["numBathrooms"]
+        return self._result["numBathrooms"]
 
     @property
     def bedrooms(self):

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -147,7 +147,6 @@ class DaftTest(unittest.TestCase):
         self.assertEqual(listing.title, "Capital Dock Residence, Grand Canal, Dublin 2")
         self.assertEqual(listing.agent_id, 9601)
         self.assertEqual(listing.bedrooms, "2 & 3 bed")
-        self.assertEqual(listing.abbreviated_price, "€2,970+")
         self.assertEqual(listing.has_brochure, False)
         self.assertEqual(
             listing.daft_link,


### PR DESCRIPTION
This would close #124. For comparison with the example given in the issue, with these changes running:

```
import pandas as pd
from daftlistings import Daft, Location, SearchType, PropertyType, SortType, MapVisualization
 
daft = Daft()
daft.set_location(Location.DUBLIN)
daft.set_search_type(SearchType.RESIDENTIAL_RENT)
daft.set_property_type(PropertyType.APARTMENT)
daft.set_sort_type(SortType.PRICE_DESC)
daft.set_min_price(7500)

listings = daft.search()

# cache the listings in the local file
with open("result.txt", "w") as fp:
    fp.writelines("%s\n" % listing.as_dict_for_mapping() for listing in listings)

# read from the local file
with open("result.txt") as fp:
  lines = fp.readlines()

properties = []
for line in lines:
  properties.append(eval(line))

df = pd.DataFrame(properties)
print(df)
```

returns:

![daft3](https://user-images.githubusercontent.com/52505873/113728491-109c6580-96ee-11eb-9092-5be1784e2062.jpg)

The listings at index 2 and 3 are two different types of apartment within the same development which have now been expanded as different listings. 

As part of this change the abbreviated_price attribute of `Listing` was removed because the search results do not give us an "abbreviated_price" for each of the sublistings. This attribute was not being used for anything later on anyway. It also removes the need for the check that was previously included in `Listing.bathrooms`, as issue #124 was the reason why this was needed too. 

The computation of number of results also has to be moved until after we expand the listings as we no longer know the total number of listings just from the initial request.

The only potential issue I can see with this is that, in the search above for example, now the map visualisation will place 2 markers on the same location for those results indexed 2 and 3. Only one of these is visible and clickable to get its information. It probably makes the most sense to adjust map_visualisation so that only one marker is plotted but the information box for it contains the details for both properties. 

