### PR TITLE
Sublistings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
     # ...
 ```
@@ -60,7 +60,7 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
 ```
 
@@ -80,7 +80,7 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
 ```
 
@@ -97,7 +97,7 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
 ```
 
@@ -113,7 +113,7 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
     print()
 ```
@@ -138,7 +138,7 @@ listings.sort(key=lambda x: x.distance_to(dublin_castle_coords))
 for listing in listings:
     print(f'{listing.title}')
     print(f'{listing.daft_link}')
-    print(f'{listing.abbreviated_price}')
+    print(f'{listing.price}')
     print(f'{listing.distance_to(dublin_castle_coords):.3}km')
     print('')
 
@@ -196,7 +196,7 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
     print()
 ```

--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -234,32 +234,32 @@ class Daft:
             listings = listings + r.json()["listings"]
 
         # expand out grouped listings as individual listings, commercial searches do not give the necessary information to do this
-        if self._section not in [SearchType.COMMERCIAL_SALE.value, SearchType.COMMERCIAL_RENT.value]:
-            expanded_listings = []
-            for l in listings:
-                # the information contained in the key 'prs' for most searches is instead contained in 'newHome' for newHome type searches
-                if 'newHome' in l['listing'].keys():
-                    if 'subUnits' in l['listing']['newHome'].keys():
-                        l['listing']['prs'] = l['listing'].pop('newHome')
-                if 'prs' in l['listing'].keys():
-                    num_subUnits = len(l['listing']['prs']['subUnits'])
-                    for i in range(num_subUnits):
-                        copy = deepcopy(l)            
-                        for key in copy['listing']['prs']['subUnits'][i].keys(): 
-                            copy['listing'][key] = copy['listing']['prs']['subUnits'][i][key]
 
-                        # studios do not have a 'numBedrooms' so set it separately 
-                        if copy['listing']['propertyType'] == 'Studio':
-                            copy['listing']['numBedrooms'] = '1 bed'                         
-                        expanded_listings.append(copy)
-                else:    
-                    # above only sets studio 'numBedrooms' for grouped listings, do ungrouped here
-                    if 'propertyType' in l['listing'].keys():
-                        if l['listing']['propertyType'] == 'Studio':
-                                l['listing']['numBedrooms'] = '1 bed'            
-                    expanded_listings.append(l)         
+        expanded_listings = []
+        for l in listings:
+            # the information contained in the key 'prs' for most searches is instead contained in 'newHome' for newHome type searches
+            if 'newHome' in l['listing'].keys():
+                if 'subUnits' in l['listing']['newHome'].keys():
+                    l['listing']['prs'] = l['listing'].pop('newHome')
+            try:
+                num_subUnits = len(l['listing']['prs']['subUnits'])
+                for i in range(num_subUnits):
+                    copy = deepcopy(l)            
+                    for key in copy['listing']['prs']['subUnits'][i].keys(): 
+                        copy['listing'][key] = copy['listing']['prs']['subUnits'][i][key]
 
-            listings = expanded_listings
+                    # studios do not have a 'numBedrooms' so set it separately 
+                    if copy['listing']['propertyType'] == 'Studio':
+                        copy['listing']['numBedrooms'] = '1 bed'                         
+                    expanded_listings.append(copy)
+            except:    
+                # above only sets studio 'numBedrooms' for grouped listings, do ungrouped here
+                if 'propertyType' in l['listing'].keys():
+                    if l['listing']['propertyType'] == 'Studio':
+                            l['listing']['numBedrooms'] = '1 bed'            
+                expanded_listings.append(l)         
+
+        listings = expanded_listings
 
         print(f"Got {len(listings)} results.")
         

--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -21,6 +21,7 @@ class Daft:
     _PAGE_0 = {"from": "0", "pagesize": str(_PAGE_SZ)}
 
     def __init__(self):
+        self._section = None
         self._filters = list()
         self._andFilters = list()
         self._ranges = list()

--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -3,6 +3,7 @@ import requests
 from typing import Union, Optional, List, Dict
 from math import ceil
 from difflib import SequenceMatcher
+from copy import deepcopy
 
 from .enums import *
 from .listing import Listing
@@ -232,5 +233,19 @@ class Daft:
                               headers=self._HEADER,
                               json=_payload)
             listings = listings + r.json()["listings"]
-        return [Listing(l) for l in listings]
+
+
+        expanded_listings = []
+        for l in listings:
+            if 'prs' in l['listing'].keys():
+                subUnit_keys = ['id', 'price', 'numBedrooms', 'numBathrooms', 'daftShortcode', 'seoFriendlyPath', 'category', 'media', 'ber']
+                num_subUnits = len(l['listing']['prs']['subUnits'])
+                for i in range(num_subUnits):   
+                    for key in subUnit_keys:     
+                        l['listing'][key] = l['listing']['prs']['subUnits'][i][key]
+                    expanded_listings.append(deepcopy(l))
+            else:
+                expanded_listings.append(l)
+
+        return [Listing(l) for l in expanded_listings]
 

--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -21,7 +21,6 @@ class Daft:
     _PAGE_0 = {"from": "0", "pagesize": str(_PAGE_SZ)}
 
     def __init__(self):
-        self._section = None
         self._filters = list()
         self._andFilters = list()
         self._ranges = list()
@@ -222,7 +221,6 @@ class Daft:
                           json=_payload)
         listings = r.json()["listings"]
         results_count = r.json()["paging"]["totalResults"]
-        print(f"Got {results_count} results.")
 
         total_pages = ceil(results_count / self._PAGE_SZ)
         limit = min(max_pages, total_pages) if max_pages else total_pages
@@ -234,11 +232,10 @@ class Daft:
                               json=_payload)
             listings = listings + r.json()["listings"]
 
-
         expanded_listings = []
+        subUnit_keys = ['id', 'price', 'numBedrooms', 'numBathrooms', 'daftShortcode', 'seoFriendlyPath', 'category', 'media', 'ber']
         for l in listings:
             if 'prs' in l['listing'].keys():
-                subUnit_keys = ['id', 'price', 'numBedrooms', 'numBathrooms', 'daftShortcode', 'seoFriendlyPath', 'category', 'media', 'ber']
                 num_subUnits = len(l['listing']['prs']['subUnits'])
                 for i in range(num_subUnits):   
                     for key in subUnit_keys:     
@@ -246,6 +243,9 @@ class Daft:
                     expanded_listings.append(deepcopy(l))
             else:
                 expanded_listings.append(l)
+
+        expanded_results_count = len(expanded_listings) 
+        print(f"Got {expanded_results_count} results.")
 
         return [Listing(l) for l in expanded_listings]
 

--- a/daftlistings/listing.py
+++ b/daftlistings/listing.py
@@ -59,6 +59,10 @@ class Listing:
             return price_num
 
     @property
+    def price(self):
+         return self._result["price"]
+
+    @property
     def bathrooms(self):
         if "numBathrooms" in self._result:
             return self._result["numBathrooms"]

--- a/daftlistings/listing.py
+++ b/daftlistings/listing.py
@@ -59,13 +59,8 @@ class Listing:
             return price_num
 
     @property
-    def abbreviated_price(self):
-        return self._result["abbreviatedPrice"]
-
-    @property
     def bathrooms(self):
-        if "numBathrooms" in self._result:
-            return self._result["numBathrooms"]
+        return self._result["numBathrooms"]
 
     @property
     def bedrooms(self):

--- a/daftlistings/listing.py
+++ b/daftlistings/listing.py
@@ -60,7 +60,8 @@ class Listing:
 
     @property
     def bathrooms(self):
-        return self._result["numBathrooms"]
+        if "numBathrooms" in self._result:
+            return self._result["numBathrooms"]
 
     @property
     def bedrooms(self):

--- a/daftlistings/map_visualization.py
+++ b/daftlistings/map_visualization.py
@@ -1,4 +1,5 @@
 import folium
+from folium.plugins import MarkerCluster
 import branca.colormap as cm
 
 
@@ -56,6 +57,7 @@ class MapVisualization:
         return folium.Icon(color=self.color_dispatcher(price))
 
     def add_markers(self):
+        markers_dict = {}
         for index, row in self.df.iterrows():
             lat, lon, price = row["latitude"], row["longitude"], row["monthly_price"]
             beds, baths = row["bedrooms"], row["bathrooms"]
@@ -76,7 +78,18 @@ class MapVisualization:
             marker = folium.Marker(
                 [lat, lon], popup=popup_name, tooltip=price, icon=icon
             )
-            marker.add_to(self.map)
+            if (lat,lon) in markers_dict.keys():
+                markers_dict[(lat,lon)].append(marker)
+            else:
+                markers_dict[(lat,lon)] = [marker]
+
+        for key, item in markers_dict.items():
+            if len(item) == 1:
+                item[0].add_to(self.map)
+            else:
+                marker_cluster = MarkerCluster().add_to(self.map)
+                for i in range(len(item)):
+                    item[i].add_to(marker_cluster)
 
     def add_colorbar(self):
         """add a colorbar at the top right corner of the map"""

--- a/examples/commercial_listings.py
+++ b/examples/commercial_listings.py
@@ -7,7 +7,7 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
     print()
 

--- a/examples/facilities.py
+++ b/examples/facilities.py
@@ -11,6 +11,6 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
     print()

--- a/examples/properties_for_rent.py
+++ b/examples/properties_for_rent.py
@@ -9,6 +9,6 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
     print()

--- a/examples/properties_for_sale.py
+++ b/examples/properties_for_sale.py
@@ -11,6 +11,6 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
     print()

--- a/examples/sort.py
+++ b/examples/sort.py
@@ -9,6 +9,6 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
     print()

--- a/examples/sort_by_distance.py
+++ b/examples/sort_by_distance.py
@@ -16,6 +16,6 @@ listings.sort(key=lambda x: x.distance_to(dublin_castle_coords))
 for listing in listings:
     print(f'{listing.title}')
     print(f'{listing.daft_link}')
-    print(f'{listing.abbreviated_price}')
+    print(f'{listing.price}')
     print(f'{listing.distance_to(dublin_castle_coords):.3}km')
     print('')

--- a/examples/student_accomodation.py
+++ b/examples/student_accomodation.py
@@ -8,6 +8,6 @@ listings = daft.search()
 
 for listing in listings:
     print(listing.title)
-    print(listing.abbreviated_price)
+    print(listing.price)
     print(listing.daft_link)
     print()

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -207,7 +207,6 @@ class DaftTest(unittest.TestCase):
         listings = daft.search(max_pages=1)
         self.assertTrue(len(listings) > 0)
         self.assertTrue(listings[0].bedrooms == '1 bed')
-        self.assertTrue(listings[0].bathrooms == '1 bath')
 
     def test_distance(self):
         daft = Daft()

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -146,6 +146,7 @@ class DaftTest(unittest.TestCase):
         self.assertEqual(listing.id, 1443907)
         self.assertEqual(listing.title, "Capital Dock Residence, Grand Canal, Dublin 2")
         self.assertEqual(listing.agent_id, 9601)
+        self.assertEqual(listing.price, "From €2,970 per month")
         self.assertEqual(listing.bedrooms, "2 & 3 bed")
         self.assertEqual(listing.has_brochure, False)
         self.assertEqual(

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -147,7 +147,6 @@ class DaftTest(unittest.TestCase):
         self.assertEqual(listing.title, "Capital Dock Residence, Grand Canal, Dublin 2")
         self.assertEqual(listing.agent_id, 9601)
         self.assertEqual(listing.bedrooms, "2 & 3 bed")
-        self.assertEqual(listing.abbreviated_price, "€2,970+")
         self.assertEqual(listing.has_brochure, False)
         self.assertEqual(
             listing.daft_link,

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -207,6 +207,13 @@ class DaftTest(unittest.TestCase):
         self.assertTrue(len(listings) > 0)
         self.assertTrue(listings[0].bedrooms == '1 bed')
 
+    def test_new_homes(self):
+        daft = Daft()
+        daft.set_search_type(SearchType.NEW_HOMES)
+        daft.set_location(Location.DUBLIN)
+        listings = daft.search(max_pages=1)
+        self.assertTrue(len(listings) > 0)
+
     def test_distance(self):
         daft = Daft()
         daft.set_location("Dublin City")

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -205,6 +205,8 @@ class DaftTest(unittest.TestCase):
         daft.set_location(Location.DUBLIN)
         listings = daft.search(max_pages=1)
         self.assertTrue(len(listings) > 0)
+        self.assertTrue(listings[0].bedrooms == '1 bed')
+        self.assertTrue(listings[0].bathrooms == '1 bath')
 
     def test_distance(self):
         daft = Daft()
@@ -213,7 +215,11 @@ class DaftTest(unittest.TestCase):
         daft.set_min_price(1)
         daft.set_max_price(100000)
         listings = daft.search(max_pages=1)
-        first, second = listings[0], listings[1]
+        first = listings[0]
+        for l in listings[1:]:
+            if (l.latitude, l.longitude) != (first.latitude, first.longitude):
+                second = l
+                break
         coord = [53.3429, -6.2674]
         self.assertGreater(first.distance_to(coord), 0)
         self.assertGreater(first.distance_to(second), 0)

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -147,6 +147,7 @@ class DaftTest(unittest.TestCase):
         self.assertEqual(listing.title, "Capital Dock Residence, Grand Canal, Dublin 2")
         self.assertEqual(listing.agent_id, 9601)
         self.assertEqual(listing.bedrooms, "2 & 3 bed")
+        self.assertEqual(listing.abbreviated_price, "€2,970+")
         self.assertEqual(listing.has_brochure, False)
         self.assertEqual(
             listing.daft_link,


### PR DESCRIPTION
Work on expanding out grouped listings as individual listings. This is applied to every search type except the commercial ones, as in those cases the information needed to expand in this way is not returned by the search. This is a bit awkward to do because of some strange variation in what information the search returns across different search types. For example the information on sublistings is generally included in `l['listing']['prs']` but in the case of a `New_Homes` search it is in `l['listing']['newHome']`. In the former cases it seems that whenever a grouped result is given by the search, the sublisting information is **always** returned by the search. However for some reason in the New Homes case this is not true, and sometimes even though we have a grouped search result, the information needed to expand it is not provided. This all ends up being reflected in how it is implemented. As a result the code is probably not as clean as it was previously, so let me know if anything should be changed here before merging.

This would close #124. For comparison with the example given in the issue, with these changes running:

```python
import pandas as pd
from daftlistings import Daft, Location, SearchType, PropertyType, SortType, MapVisualization
 
daft = Daft()
daft.set_location(Location.DUBLIN)
daft.set_search_type(SearchType.RESIDENTIAL_RENT)
daft.set_property_type(PropertyType.APARTMENT)
daft.set_sort_type(SortType.PRICE_DESC)
daft.set_min_price(7500)

listings = daft.search()

# cache the listings in the local file
with open("result.txt", "w") as fp:
    fp.writelines("%s\n" % listing.as_dict_for_mapping() for listing in listings)

# read from the local file
with open("result.txt") as fp:
  lines = fp.readlines()

properties = []
for line in lines:
  properties.append(eval(line))

df = pd.DataFrame(properties)
print(df)
```
returns:

![daft3](https://user-images.githubusercontent.com/52505873/114287764-7cb9f900-9a61-11eb-9909-84e7bf0c0335.jpg)

i.e. prices as well as bedrooms and bathrooms are now correct for grouped listings

The information for sublistings does not include `abbreviatedPrice` so this property can not be corrected when we expand listings. I've just removed it as an attribute since we never actually use it anyway, as we just use `price` instead.

Also updated some tests for compatibility with this. 

I've also now updated map_visualisation.py for compatibility with this too. When two listings have the exact same coordiantes it will now cluster them, with a cluster on the map showing the number of listings at that location which can be expanded to view them. For example the search above now results in the following map initially:

![map1](https://user-images.githubusercontent.com/52505873/114288496-55b2f580-9a68-11eb-8b10-31672aff76a9.jpg)

and expanding the cluster:

![map2](https://user-images.githubusercontent.com/52505873/114288500-5e0b3080-9a68-11eb-809a-e10b4e4e3e23.jpg)





