### PR TITLE
Added "size_meters_squared" property to listing class

### DIFF
--- a/daftlistings/listing.py
+++ b/daftlistings/listing.py
@@ -126,6 +126,16 @@ class Listing:
     def featured_level(self):
         return self._result["featuredLevel"]
 
+    @property
+    def size_meters_squared(self):
+        try:
+            if self._result["floorArea"]["unit"] != "METRES_SQUARED":
+                return "N/A"
+            else:
+                return self._result["floorArea"]["value"]
+        except KeyError as e:
+            return "N/A"
+
     def as_dict(self):
         return self._result
     

--- a/tests/fixtures/response.json
+++ b/tests/fixtures/response.json
@@ -84,6 +84,10 @@
         "ber": {
           "rating": "A2A3"
         },
+        "floorArea": {
+          "unit": "METRES_SQUARED",
+          "value": 75
+        },
         "point": {
           "type": "Point",
           "coordinates": [

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -231,6 +231,7 @@ class DaftTest(unittest.TestCase):
         self.assertIsNotNone(listing.images)
         self.assertIsInstance(listing.images, list)
         self.assertEqual(listing.ber, "A2A3")
+        self.assertEqual(listing.size_meters_squared, 75)
         self.assertEqual(listing.has_video, True)
         self.assertEqual(listing.has_virtual_tour, False)
         self.assertEqual(listing.longitude, -6.231118982370589)


### PR DESCRIPTION
I wanted house size for a personal project so I added it.

From a bit of testing about 25% of listings don't have sizes listed hence the error handling

Property name isn't great