### PR TITLE
Clean up requirements.txt and install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-folium==0.12.1
-requests==2.25.1
+folium
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,2 @@
-branca==0.4.2
-certifi==2020.12.5
-chardet==4.0.0
 folium==0.12.1
-idna==2.10
-Jinja2==2.11.3
-MarkupSafe==1.1.1
-numpy==1.22.0
 requests==2.25.1
-urllib3==1.26.5

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(name='daftlistings',
       license='MIT',
       packages=['daftlistings'],
       install_requires=[
-          'enum34',
           'requests',
           'folium'
       ],


### PR DESCRIPTION
The old `requirements.txt` had this form (brackets show what package installed it if any)
````
branca==0.4.2	        (folium)
certifi==2020.12.5      (requests)
chardet==4.0.0
folium==0.12.1
idna==2.10              (requests)
Jinja2==2.11.3          (folium)
MarkupSafe==1.1.1       (jinja2)
numpy==1.22.0           (folium)
requests==2.25.1
urllib3==1.26.5         (requests)
````
- `chardet` is not needed.
- `enum34` in the `install_requires` is for compatibility with versions of python that are end-of-lifed.
- Unpinned the version of `requests` and `folium` to match the `install_requires`.