### PR TITLE
Update API endpoint URL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -11,7 +11,7 @@ from .location import Location
 
 
 class Daft:
-    _ENDPOINT = "https://gateway.daft.ie/old/v1/listings"
+    _ENDPOINT = "https://gateway.daft.ie/api/v2/ads/listings"
     _HEADER = {
         "User-Agent": "",
         "Content-Type": "application/json",

--- a/tests/test_daft_search.py
+++ b/tests/test_daft_search.py
@@ -20,7 +20,7 @@ from daftlistings.enums import Distance
 class DaftTest(unittest.TestCase):
     @patch("requests.post")
     def test_search_basic(self, mock_post):
-        url = "https://gateway.daft.ie/old/v1/listings"
+        url = "https://gateway.daft.ie/api/v2/ads/listings"
         payload = {
             "paging": {"from": "0", "pagesize": "50"},
         }
@@ -37,7 +37,7 @@ class DaftTest(unittest.TestCase):
 
     @patch("requests.post")
     def test_search_properties_for_sale(self, mock_post):
-        url = "https://gateway.daft.ie/old/v1/listings"
+        url = "https://gateway.daft.ie/api/v2/ads/listings"
         payload = {
             "section": "residential-for-sale",
             "andFilters": [
@@ -94,7 +94,7 @@ class DaftTest(unittest.TestCase):
 
     @patch("requests.post")
     def test_search_properties_for_rent(self, mock_post):
-        url = "https://gateway.daft.ie/old/v1/listings"
+        url = "https://gateway.daft.ie/api/v2/ads/listings"
         payload = {
             "section": "residential-to-rent",
             "andFilters": [
@@ -145,7 +145,7 @@ class DaftTest(unittest.TestCase):
 
     @patch("requests.post")
     def test_search_multiple_areas(self, mock_post):
-        url = "https://gateway.daft.ie/old/v1/listings"
+        url = "https://gateway.daft.ie/api/v2/ads/listings"
         payload = {
             "section": "residential-to-rent",
             "geoFilter": {
@@ -173,7 +173,7 @@ class DaftTest(unittest.TestCase):
 
     @patch("requests.post")
     def test_shared_listings(self, mock_post):
-        url = "https://gateway.daft.ie/old/v1/listings"
+        url = "https://gateway.daft.ie/api/v2/ads/listings"
         payload = {
             "section": "sharing",
             "filters": [


### PR DESCRIPTION
This PR updates the Daft API endpoint from https://gateway.daft.ie/old/v1/listings to https://gateway.daft.ie/api/v2/ads/listings. The previous endpoint doesn't seem to be working anymore (returns a HTTP 403).

All tests have been run and are passing with the updated endpoint. Code formatting checked with Black.