### PR TITLE
Fix silent error handling in Daft.search() 

### DIFF
--- a/daftlistings/daft.py
+++ b/daftlistings/daft.py
@@ -267,14 +267,17 @@ class Daft:
         print("Searching...")
         _payload = self._make_payload()
         r = requests.post(self._ENDPOINT, headers=self._headers, json=_payload)
-        listings = r.json()["listings"]
-        results_count = r.json()["paging"]["totalResults"]
+        r.raise_for_status()
+        body = r.json()
+        listings = body["listings"]
+        results_count = body["paging"]["totalResults"]
         total_pages = ceil(results_count / self._PAGE_SZ)
         limit = min(max_pages, total_pages) if max_pages else total_pages
 
         for page in range(1, limit):
             _payload["paging"]["from"] = page * self._PAGE_SZ
             r = requests.post(self._ENDPOINT, headers=self._headers, json=_payload)
+            r.raise_for_status()
             listings = listings + r.json()["listings"]
 
         # expand out grouped listings as individual listings, commercial searches do not give the necessary information to do this
@@ -298,7 +301,7 @@ class Daft:
                     if copy["listing"]["propertyType"] == "Studio":
                         copy["listing"]["numBedrooms"] = "1 bed"
                     expanded_listings.append(copy)
-            except:
+            except (KeyError, TypeError):
                 # above only sets studio 'numBedrooms' for grouped listings, do ungrouped here
                 if "propertyType" in l["listing"].keys():
                     if l["listing"]["propertyType"] == "Studio":


### PR DESCRIPTION
## Summary                                                                                                                                       
  - `Daft.search()` previously ignored HTTP error status codes — a 429 or 5xx from the Daft gateway crashed with a confusing `KeyError: 'listings'`
   instead of a clear `HTTPError`. Added `r.raise_for_status()` after each POST.                                                                   
  - The page-0 response was parsed twice via `r.json()` back-to-back. Now parsed once into a local `body`.
  - The sub-unit expansion block used a bare `except:` that swallowed *every* exception, including `KeyboardInterrupt` and `SystemExit`, and would 
  silently mask real schema bugs by routing affected listings into the ungrouped fallback path. Narrowed to `except (KeyError, TypeError)` — the   
  only exceptions the surrounding dict/list access can legitimately raise.                                                                         
                                                                                                                                                   
  ## Why                                                    
  These were silent-failure paths: callers got either a misleading traceback or incomplete results with no signal. Tightening error handling makes failures loud and debuggable without changing the happy path.                                                                                    
   
  ## Test plan                                                                                                                                     
  - [ ] `python -m unittest discover tests/` — existing suite still passes (covers payload shape and the success path).
  - [ ] Manual: point `_ENDPOINT` at a URL that returns 500; confirm `HTTPError` is raised instead of `KeyError`.                                  
  - [ ] (Follow-up) Add unit tests for the new error paths — not included in this PR.                          